### PR TITLE
Update depends on file in migration

### DIFF
--- a/migrations/v10x/m1_initial_schema.php
+++ b/migrations/v10x/m1_initial_schema.php
@@ -24,7 +24,7 @@ class m1_initial_schema extends \phpbb\db\migration\migration
 	*/
 	static public function depends_on()
 	{
-		return array('\phpbb\db\migration\data\v310\beta4');
+		return array('\phpbb\db\migration\data\v310\contact_admin_form');
 	}
 
 	/**


### PR DESCRIPTION
This ext depends on changes made after beta4 was released. It depends on changes that came with the ACP Contact Admin form, so I'm changing the 1st migration to depend on that change's migration. Maybe this should be changed again to beta5 later on, but for now this could prevent installs on out-dated versions of phpBB (which have already occurred).
