### PR TITLE
Use div tags instead of P, for BBcode compatibility

### DIFF
--- a/adm/style/board_announcements.html
+++ b/adm/style/board_announcements.html
@@ -40,7 +40,7 @@
 	<!-- IF BOARD_ANNOUNCEMENTS_PREVIEW -->
 		<fieldset>
 			<legend>{L_BOARD_ANNOUNCEMENTS_PREVIEW}</legend>
-			<p style="padding:10px; font-size:1.0em; <!-- IF BOARD_ANNOUNCEMENTS_BGCOLOR -->background-color:#{BOARD_ANNOUNCEMENTS_BGCOLOR}<!-- ENDIF -->">{BOARD_ANNOUNCEMENTS_PREVIEW}</p>
+			<div style="padding:10px; font-size:1.0em; overflow: auto; <!-- IF BOARD_ANNOUNCEMENTS_BGCOLOR -->background-color:#{BOARD_ANNOUNCEMENTS_BGCOLOR}<!-- ENDIF -->">{BOARD_ANNOUNCEMENTS_PREVIEW}</div>
 		</fieldset>
 	<!-- ENDIF -->
 

--- a/styles/all/template/event/overall_header_content_before.html
+++ b/styles/all/template/event/overall_header_content_before.html
@@ -3,7 +3,7 @@
 	<div id="phpbb_announcement"<!-- IF BOARD_ANNOUNCEMENT_BGCOLOR --> style="background-color:#{BOARD_ANNOUNCEMENT_BGCOLOR}"<!-- ENDIF -->>
 		<div class="inner">
 			<a href="{U_BOARD_ANNOUNCEMENT_CLOSE}" data-ajax="close_announcement" data-overlay="false" class="close" title="{L_BOARD_ANNOUNCEMENT_CLOSE}"></a>
-			<p>{BOARD_ANNOUNCEMENT}</p>
+			<div>{BOARD_ANNOUNCEMENT}</div>
 		</div>
 	</div>
 <!-- ENDIF -->

--- a/styles/all/theme/boardannouncements.css
+++ b/styles/all/theme/boardannouncements.css
@@ -13,10 +13,11 @@
 }
 
 /* zero out any text margins and scroll any overflow */
-#phpbb_announcement .inner p {
+#phpbb_announcement .inner div {
 	margin: 0;
 	overflow-x: auto;
 	overflow: hidden;
+	font-size: 1.1em;
 	line-height: 1.5em;
 }
 


### PR DESCRIPTION
Because BBCodes may introduce div tags and other tags not valid inside of P tags, we should replace the use of P tags with DIV tags instead for the output of the message content..
