### PR TITLE
Javascript protections

### DIFF
--- a/adm/style/board_announcements.html
+++ b/adm/style/board_announcements.html
@@ -1,15 +1,11 @@
 <!-- INCLUDE overall_header.html -->
 
-<script type="text/javascript">
-// <![CDATA[
-
+<script>
 	var form_name = 'acp_board_announcements';
 	var text_name = 'board_announcements_text';
 	var load_draft = false;
 	var upload = false;
 	var imageTag = false;
-
-// ]]>
 </script>
 
 <a id="maincontent"></a>

--- a/adm/style/event/acp_overall_footer_after.html
+++ b/adm/style/event/acp_overall_footer_after.html
@@ -5,9 +5,7 @@
 	<!-- DEFINE $INCLUDEDED_COLPICKJS = true -->
 <!-- ENDIF -->
 
-<script type="text/javascript">
-// <![CDATA[
-
+<script>
 jQuery(function($) {
 	var bgcolor = '{BOARD_ANNOUNCEMENTS_BGCOLOR}';
 	$('#board_announcements_bgcolor').colpick({
@@ -33,8 +31,6 @@ jQuery(function($) {
 		$(this).colpickSetColor(this.value || 'ffffff');
 	});
 });
-
-// ]]>
 </script>
 
 <!-- ENDIF -->


### PR DESCRIPTION
Added something discussed in Copenhagen: to prevent the same libraries from being included more than once, we came up with this concept (to be published on the website with the new Extension guidelines):

```
<!-- IF not $INCLUDEDED_COLPICKJS -->
    <!-- INCLUDEJS @phpbb_boardannouncements/colpick.js -->
    <!-- DEFINE $INCLUDEDED_COLPICKJS = true -->
<!-- ENDIF -->
```

The idea is that any extensions that would use the colpick.js should include it in this manner, to prevent multiple inclusions. There is no standardization of this as of yet, considering all the potential thousands of libraries out there, but we will build a list of these as time goes on, on the website. The basic idea would be to use the name of the JS file for the template variable definition, so in this case, `colpick.js` is defined as `$INCLUDEDED_COLPICKJS`.

The theory would apply to other libraries as well, ie: `$INCLUDEDED_HIGHSLIDEJS, $INCLUDEDED_MOTOOLSJS`

This extension gives us a good opportunity to show this method in action.
