### PR TITLE
Minor changes to the placement of ACP options

### DIFF
--- a/adm/style/board_announcements.html
+++ b/adm/style/board_announcements.html
@@ -27,22 +27,10 @@
 		<dl>
 			<dt><label for="board_announcements_enable">{L_BOARD_ANNOUNCEMENTS_ENABLE}{L_COLON}</label></dt>
 			<dd>
-				<label><input type="radio" class="radio" id="board_announcements_enable" name="board_announcements_enable" value="1"<!-- IF BOARD_ANNOUNCEMENTS_ENABLED --> checked="checked"<!-- ENDIF --> /> {L_ENABLED}</label>
-				<label><input type="radio" class="radio" name="board_announcements_enable" value="0"<!-- IF not BOARD_ANNOUNCEMENTS_ENABLED --> checked="checked"<!-- ENDIF --> /> {L_DISABLED}</label>
+				<label><input type="radio" class="radio" id="board_announcements_enable" name="board_announcements_enable" value="1"<!-- IF BOARD_ANNOUNCEMENTS_ENABLED --> checked="checked"<!-- ENDIF --> /> {L_YES}</label>
+				<label><input type="radio" class="radio" name="board_announcements_enable" value="0"<!-- IF not BOARD_ANNOUNCEMENTS_ENABLED --> checked="checked"<!-- ENDIF --> /> {L_NO}</label>
 			</dd>
 		</dl>
-	</fieldset>
-
-	<!-- IF BOARD_ANNOUNCEMENTS_PREVIEW -->
-		<fieldset>
-			<legend>{L_BOARD_ANNOUNCEMENTS_PREVIEW}</legend>
-			<div style="padding:10px; font-size:1.0em; overflow: auto; <!-- IF BOARD_ANNOUNCEMENTS_BGCOLOR -->background-color:#{BOARD_ANNOUNCEMENTS_BGCOLOR}<!-- ENDIF -->">{BOARD_ANNOUNCEMENTS_PREVIEW}</div>
-		</fieldset>
-	<!-- ENDIF -->
-
-	<fieldset>
-		<legend>{L_BOARD_ANNOUNCEMENTS_TEXT}</legend>
-
 		<dl>
 			<dt><label for="board_announcements_enable">{L_BOARD_ANNOUNCEMENTS_GUESTS}{L_COLON}</label></dt>
 			<dd>
@@ -57,9 +45,17 @@
 				<label><input type="radio" class="radio" name="board_announcements_dismiss" value="0"<!-- IF not BOARD_ANNOUNCEMENTS_DISMISS --> checked="checked"<!-- ENDIF --> /> {L_NO}</label>
 			</dd>
 		</dl>
+	</fieldset>
 
-		<br />
+	<!-- IF BOARD_ANNOUNCEMENTS_PREVIEW -->
+		<fieldset>
+			<legend>{L_BOARD_ANNOUNCEMENTS_PREVIEW}</legend>
+			<div style="padding:10px; font-size:1.0em; overflow: auto; <!-- IF BOARD_ANNOUNCEMENTS_BGCOLOR -->background-color:#{BOARD_ANNOUNCEMENTS_BGCOLOR}<!-- ENDIF -->">{BOARD_ANNOUNCEMENTS_PREVIEW}</div>
+		</fieldset>
+	<!-- ENDIF -->
 
+	<fieldset>
+		<legend>{L_BOARD_ANNOUNCEMENTS_TEXT}</legend>
 		<dl>
 			<dt><label for="board_announcements_bgcolor">{L_BOARD_ANNOUNCEMENTS_BGCOLOR}{L_COLON}</label><br /><span>{L_BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN}</span></dt>
 			<dd>

--- a/language/en/boardannouncements_acp.php
+++ b/language/en/boardannouncements_acp.php
@@ -41,7 +41,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS'			=> 'Board announcements settings',
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Here you can manage and create a board announcement that will be displayed on each page of your board.',
 
-	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Show board announcement',
+	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Display this board announcement',
 	'BOARD_ANNOUNCEMENTS_GUESTS'			=> 'Allow guests to view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Allow users to dismiss this board announcement',
 


### PR DESCRIPTION
Now that we have some more options, I think it looks better to put all the yes/no switches together, like so:
![screen shot 2014-11-08 at 9 32 52 pm](https://cloud.githubusercontent.com/assets/303711/4966573/46ae343e-67d2-11e4-9cc7-d7078e8803a2.png)
