### PR TITLE
Add option for guests only

### DIFF
--- a/acp/board_announcements_module.php
+++ b/acp/board_announcements_module.php
@@ -152,8 +152,8 @@ class board_announcements_module
 				));
 
 				$announcement_text = (!empty($data['announcement_text']));
-				$guests_only  = $allowed_users === self::GUESTS;
-				$members_only = $allowed_users === self::MEMBERS;
+				$guests_only  = ($allowed_users === self::GUESTS);
+				$members_only = ($allowed_users === self::MEMBERS);
 
 				$this->db->sql_transaction('begin');
 

--- a/acp/board_announcements_module.php
+++ b/acp/board_announcements_module.php
@@ -12,6 +12,10 @@ namespace phpbb\boardannouncements\acp;
 
 class board_announcements_module
 {
+	const ALL = 0;
+	const MEMBERS = 1;
+	const GUESTS = 2;
+
 	/** @var \phpbb\cache\driver\driver_interface */
 	protected $cache;
 
@@ -109,7 +113,7 @@ class board_announcements_module
 
 			// Get config options from the form
 			$enable_announcements = $this->request->variable('board_announcements_enable', false);
-			$allow_guests = $this->request->variable('board_announcements_guests', false);
+			$allowed_users = $this->request->variable('board_announcements_users', self::ALL);
 			$dismiss_announcements = $this->request->variable('board_announcements_dismiss', false);
 
 			// Prepare announcement text for storage
@@ -128,7 +132,7 @@ class board_announcements_module
 			{
 				// Store the config enable/disable state
 				$this->config->set('board_announcements_enable', $enable_announcements);
-				$this->config->set('board_announcements_guests', $allow_guests);
+				$this->config->set('board_announcements_users', $allowed_users);
 				$this->config->set('board_announcements_dismiss', $dismiss_announcements);
 
 				// Store the announcement settings to the config_table in the database
@@ -141,11 +145,15 @@ class board_announcements_module
 					'announcement_timestamp'	=> time(),
 				));
 
-				// Set the board_announcements_status for all normal users
-				// to 1 when an announcement is created, or 0 when announcement is empty
-				$announcement_status = (!empty($data['announcement_text'])) ? 1 : 0;
+				$announcement_text = (!empty($data['announcement_text']));
+				$guests_only  = $allowed_users === self::GUESTS;
+				$members_only = $allowed_users === self::MEMBERS;
+
+				$this->db->sql_transaction('begin');
+
+				// Set the board_announcements_status for all registered users
 				$sql = 'UPDATE ' . USERS_TABLE . '
-					SET board_announcements_status = ' . $announcement_status . '
+					SET board_announcements_status = ' . ($announcement_text && !$guests_only ? 1 : 0) . '
 					WHERE user_type <> ' . USER_IGNORE;
 				$this->db->sql_query($sql);
 
@@ -153,9 +161,11 @@ class board_announcements_module
 				// We do this separately for guests to make sure it is always set to
 				// the correct value every time.
 				$sql = 'UPDATE ' . USERS_TABLE . '
-					SET board_announcements_status = ' . (($allow_guests && $announcement_status ) ? 1 : 0) . '
+					SET board_announcements_status = ' . ($announcement_text && !$members_only ? 1 : 0) . '
 					WHERE user_id = ' . ANONYMOUS;
 				$this->db->sql_query($sql);
+
+				$this->db->sql_transaction('commit');
 
 				// Log the announcement update
 				$this->log->add('admin', $this->user->data['user_id'], $this->user->ip, 'BOARD_ANNOUNCEMENTS_UPDATED_LOG');
@@ -182,11 +192,16 @@ class board_announcements_module
 		$this->template->assign_vars(array(
 			'ERRORS'						=> $error,
 			'BOARD_ANNOUNCEMENTS_ENABLED'	=> isset($enable_announcements) ? $enable_announcements : $this->config['board_announcements_enable'],
-			'BOARD_ANNOUNCEMENTS_GUESTS'	=> isset($allow_guests) ? $allow_guests : $this->config['board_announcements_guests'],
 			'BOARD_ANNOUNCEMENTS_DISMISS'	=> isset($dismiss_announcements) ? $dismiss_announcements : $this->config['board_announcements_dismiss'],
 			'BOARD_ANNOUNCEMENTS_TEXT'		=> $announcement_text_edit['text'],
 			'BOARD_ANNOUNCEMENTS_PREVIEW'	=> $announcement_text_preview,
 			'BOARD_ANNOUNCEMENTS_BGCOLOR'	=> $data['announcement_bgcolor'],
+
+			'S_BOARD_ANNOUNCEMENTS_USERS'	=> build_select(array(
+				self::ALL		=> 'BOARD_ANNOUNCEMENTS_ALL_USERS',
+				self::MEMBERS	=> 'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY',
+				self::GUESTS	=> 'BOARD_ANNOUNCEMENTS_GUESTS_ONLY',
+			), isset($allowed_users) ? $allowed_users : $this->config['board_announcements_users']),
 
 			'S_BBCODE_DISABLE_CHECKED'		=> !$announcement_text_edit['allow_bbcode'],
 			'S_SMILIES_DISABLE_CHECKED'		=> !$announcement_text_edit['allow_smilies'],

--- a/acp/board_announcements_module.php
+++ b/acp/board_announcements_module.php
@@ -47,6 +47,12 @@ class board_announcements_module
 	protected $php_ext;
 
 	/** @var string */
+	public $page_title;
+
+	/** @var string */
+	public $tpl_name;
+
+	/** @var string */
 	public $u_action;
 
 	public function main()

--- a/acp/board_announcements_module.php
+++ b/acp/board_announcements_module.php
@@ -204,9 +204,9 @@ class board_announcements_module
 			'BOARD_ANNOUNCEMENTS_BGCOLOR'	=> $data['announcement_bgcolor'],
 
 			'S_BOARD_ANNOUNCEMENTS_USERS'	=> build_select(array(
-				self::ALL		=> 'BOARD_ANNOUNCEMENTS_ALL_USERS',
-				self::MEMBERS	=> 'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY',
-				self::GUESTS	=> 'BOARD_ANNOUNCEMENTS_GUESTS_ONLY',
+				self::ALL		=> 'BOARD_ANNOUNCEMENTS_EVERYONE',
+				self::MEMBERS	=> 'G_REGISTERED',
+				self::GUESTS	=> 'G_GUESTS',
 			), isset($allowed_users) ? $allowed_users : $this->config['board_announcements_users']),
 
 			'S_BBCODE_DISABLE_CHECKED'		=> !$announcement_text_edit['allow_bbcode'],

--- a/adm/style/board_announcements.html
+++ b/adm/style/board_announcements.html
@@ -32,17 +32,16 @@
 			</dd>
 		</dl>
 		<dl>
-			<dt><label for="board_announcements_guests">{L_BOARD_ANNOUNCEMENTS_GUESTS}{L_COLON}</label></dt>
-			<dd>
-				<label><input type="radio" class="radio" id="board_announcements_guests" name="board_announcements_guests" value="1"<!-- IF BOARD_ANNOUNCEMENTS_GUESTS --> checked="checked"<!-- ENDIF --> /> {L_YES}</label>
-				<label><input type="radio" class="radio" name="board_announcements_guests" value="0"<!-- IF not BOARD_ANNOUNCEMENTS_GUESTS --> checked="checked"<!-- ENDIF --> /> {L_NO}</label>
-			</dd>
-		</dl>
-		<dl>
 			<dt><label for="board_announcements_dismiss">{L_BOARD_ANNOUNCEMENTS_DISMISS}{L_COLON}</label></dt>
 			<dd>
 				<label><input type="radio" class="radio" id="board_announcements_dismiss" name="board_announcements_dismiss" value="1"<!-- IF BOARD_ANNOUNCEMENTS_DISMISS --> checked="checked"<!-- ENDIF --> /> {L_YES}</label>
 				<label><input type="radio" class="radio" name="board_announcements_dismiss" value="0"<!-- IF not BOARD_ANNOUNCEMENTS_DISMISS --> checked="checked"<!-- ENDIF --> /> {L_NO}</label>
+			</dd>
+		</dl>
+		<dl>
+			<dt><label for="board_announcements_users">{L_BOARD_ANNOUNCEMENTS_USERS}{L_COLON}</label></dt>
+			<dd>
+				<select name="board_announcements_users">{S_BOARD_ANNOUNCEMENTS_USERS}</select>
 			</dd>
 		</dl>
 	</fieldset>

--- a/event/listener.php
+++ b/event/listener.php
@@ -10,6 +10,7 @@
 
 namespace phpbb\boardannouncements\event;
 
+use phpbb\boardannouncements\acp\board_announcements_module;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -85,6 +86,13 @@ class listener implements EventSubscriberInterface
 	{
 		// Do not continue if announcement has been disabled
 		if (!$this->config['board_announcements_enable'])
+		{
+			return;
+		}
+
+		// Do not continue if user is registered, but announcements are for guests only
+		// This is mainly a fail safe, to prevent newly reg users from seeing guest only announcements
+		if ($this->user->data['user_id'] != ANONYMOUS && $this->config['board_announcements_users'] == board_announcements_module::GUESTS)
 		{
 			return;
 		}

--- a/event/listener.php
+++ b/event/listener.php
@@ -90,8 +90,8 @@ class listener implements EventSubscriberInterface
 			return;
 		}
 
-		// Do not continue if user is registered, but announcements are for guests only
-		// This is mainly a fail safe, to prevent newly reg users from seeing guest only announcements
+		// Do not continue if user is registered, but announcement is for guests only
+		// This is to prevent newly registered users from seeing guest only announcements
 		if ($this->user->data['user_id'] != ANONYMOUS && $this->config['board_announcements_users'] == board_announcements_module::GUESTS)
 		{
 			return;

--- a/language/ar/boardannouncements_acp.php
+++ b/language/ar/boardannouncements_acp.php
@@ -43,8 +43,12 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'هنا يمكنك إدارة وإنشاء لوحات إعلانية تظهر في جميع صفحات منتداك.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'عرض لوحة الإعلانات هذه',
-	'BOARD_ANNOUNCEMENTS_GUESTS'			=> 'السماح للزوار بمشاهدة لوحة الاعلانات هذه',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'السماح للمستخدمين برفض لوحة الإعلانات هذه',
+
+	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
+	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
+	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'لون خلفية لوحة الإعلانات',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'يمكنك تغيير لون خلفية لوحة الاعلانات باستعمال كود hex (مثل: FFFF80). اترك هذا الحقل فارغا لاستعمال اللون الافتراضي.',

--- a/language/ar/boardannouncements_acp.php
+++ b/language/ar/boardannouncements_acp.php
@@ -46,9 +46,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'السماح للمستخدمين برفض لوحة الإعلانات هذه',
 
-	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
-	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
-	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
+	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'كل واحد',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'لون خلفية لوحة الإعلانات',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'يمكنك تغيير لون خلفية لوحة الاعلانات باستعمال كود hex (مثل: FFFF80). اترك هذا الحقل فارغا لاستعمال اللون الافتراضي.',

--- a/language/da/boardannouncements_acp.php
+++ b/language/da/boardannouncements_acp.php
@@ -46,9 +46,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Tillad at brugere kan afvise denne boardannoncering',
 
-	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
-	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
-	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
+	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'alle',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Baggrundsfarve',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Du kan ændre boardannonceringens baggrundsfarve med en hexcode for den ønskede farve (f.eks: FFFF80). Efterlades feltet tomt anvendes standardfarven.',

--- a/language/da/boardannouncements_acp.php
+++ b/language/da/boardannouncements_acp.php
@@ -43,8 +43,12 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Her kan du oprette og ændre annonceringer som vises på alle sider på dit board.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Aktiver boardannonceringer',
-	'BOARD_ANNOUNCEMENTS_GUESTS'			=> 'Tillad at gæster at kan læse boardannonceringer',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Tillad at brugere kan afvise denne boardannoncering',
+
+	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
+	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
+	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Baggrundsfarve',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Du kan ændre boardannonceringens baggrundsfarve med en hexcode for den ønskede farve (f.eks: FFFF80). Efterlades feltet tomt anvendes standardfarven.',

--- a/language/da/boardannouncements_acp.php
+++ b/language/da/boardannouncements_acp.php
@@ -43,10 +43,10 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Her kan du oprette og ændre annonceringer som vises på alle sider på dit board.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Aktiver boardannonceringer',
-	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Hvem kan se dette boardannonceringer',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Tillad at brugere kan afvise denne boardannoncering',
 
-	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'alle',
+	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Alle',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Baggrundsfarve',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Du kan ændre boardannonceringens baggrundsfarve med en hexcode for den ønskede farve (f.eks: FFFF80). Efterlades feltet tomt anvendes standardfarven.',

--- a/language/el/boardannouncements_acp.php
+++ b/language/el/boardannouncements_acp.php
@@ -43,7 +43,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Εδώ μπορείτε να διαχειριστείτε και να δημιουργήσετε την ανακοίνωση που θα εμφανίζεται σε κάθε σελίδα της Δ. Συζήτησή σας.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Εμφάνιση της ανακοίνωσης',
-	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Ποιος μπορεί να δει αυτή την ανακοίνωσης',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Επιτρέψτε στα μέλη να κλείνουν το πλαίσιο της ανακοίνωσης',
 
 	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Καθένας',

--- a/language/el/boardannouncements_acp.php
+++ b/language/el/boardannouncements_acp.php
@@ -46,9 +46,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Επιτρέψτε στα μέλη να κλείνουν το πλαίσιο της ανακοίνωσης',
 
-	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
-	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
-	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
+	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Καθένας',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Χρώμα φόντου ανακοίνωσης',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Μπορείτε να αλλάξετε το χρώμα του φόντου της ανακοίνωσης χρησιμοποιώντας δεκαεξαδικό κωδικό χρώματος (π.χ: FFFF80). Αφήστε αυτό το πεδίο κενό για να χρησιμοποιήσετε το προεπιλεγμένο χρώμα.',

--- a/language/el/boardannouncements_acp.php
+++ b/language/el/boardannouncements_acp.php
@@ -43,8 +43,12 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Εδώ μπορείτε να διαχειριστείτε και να δημιουργήσετε την ανακοίνωση που θα εμφανίζεται σε κάθε σελίδα της Δ. Συζήτησή σας.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Εμφάνιση της ανακοίνωσης',
-	'BOARD_ANNOUNCEMENTS_GUESTS'			=> 'Επιτρέψτε στους επισκέπτες να βλέπουν την ανακοίνωση',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Επιτρέψτε στα μέλη να κλείνουν το πλαίσιο της ανακοίνωσης',
+
+	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
+	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
+	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Χρώμα φόντου ανακοίνωσης',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Μπορείτε να αλλάξετε το χρώμα του φόντου της ανακοίνωσης χρησιμοποιώντας δεκαεξαδικό κωδικό χρώματος (π.χ: FFFF80). Αφήστε αυτό το πεδίο κενό για να χρησιμοποιήσετε το προεπιλεγμένο χρώμα.',

--- a/language/en/boardannouncements_acp.php
+++ b/language/en/boardannouncements_acp.php
@@ -45,9 +45,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Allow users to dismiss this board announcement',
 
-	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
-	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
-	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
+	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Everyone',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Board announcement background color',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'You can change the background color of the announcement using a hex code (e.g: FFFF80). Leave this field blank to use the default color.',

--- a/language/en/boardannouncements_acp.php
+++ b/language/en/boardannouncements_acp.php
@@ -42,8 +42,12 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Here you can manage and create a board announcement that will be displayed on each page of your board.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Display this board announcement',
-	'BOARD_ANNOUNCEMENTS_GUESTS'			=> 'Allow guests to view this board announcement',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Allow users to dismiss this board announcement',
+
+	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
+	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
+	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Board announcement background color',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'You can change the background color of the announcement using a hex code (e.g: FFFF80). Leave this field blank to use the default color.',

--- a/language/es/boardannouncements_acp.php
+++ b/language/es/boardannouncements_acp.php
@@ -43,7 +43,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Aquí puede gestionar y crear un anuncio del foro que se mostrará en cada página de su foro.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Mostrar este Anuncio del Foro',
-	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> '¿Quién puede ver los anuncios del foro?',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Permitir a los usuarios descartar este Anuncio del Foro',
 
 	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Todos los usarios',

--- a/language/es/boardannouncements_acp.php
+++ b/language/es/boardannouncements_acp.php
@@ -46,9 +46,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Permitir a los usuarios descartar este Anuncio del Foro',
 
-	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
-	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
-	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
+	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Todos los usarios',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Color del fondo del anuncio del foro',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Puede cambiar el color del fondo del anuncio usando código hexadecimal (por ejemplo: FFFF80). Deje este campo en blanco para usar el color por defecto.',

--- a/language/es/boardannouncements_acp.php
+++ b/language/es/boardannouncements_acp.php
@@ -43,8 +43,12 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Aquí puede gestionar y crear un anuncio del foro que se mostrará en cada página de su foro.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Mostrar este Anuncio del Foro',
-	'BOARD_ANNOUNCEMENTS_GUESTS'			=> 'Permitir a los invitados ver los anuncios del foro',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Permitir a los usuarios descartar este Anuncio del Foro',
+
+	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
+	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
+	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Color del fondo del anuncio del foro',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Puede cambiar el color del fondo del anuncio usando código hexadecimal (por ejemplo: FFFF80). Deje este campo en blanco para usar el color por defecto.',

--- a/language/et/boardannouncements_acp.php
+++ b/language/et/boardannouncements_acp.php
@@ -43,8 +43,12 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Siin lehel saad hallata ja luua foorumi teadaannet, mida näidatakse igal foorumi leheküljel.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Näita seda foorumi teadaannet',
-	'BOARD_ANNOUNCEMENTS_GUESTS'			=> 'Luba külalistel vaadata seda teadaannet',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Luba liikmetel sellest foorumi teadaandest keelduda',
+
+	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
+	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
+	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> '“Foorumi teadaande” tagatausta värv',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Sa saad muuta tagatausta värvi teadaandel, kasutades hex koodi (näiteks: FFFF80). Jäta see väli tühjaks, et kasutada vaikimisi värvi.',

--- a/language/et/boardannouncements_acp.php
+++ b/language/et/boardannouncements_acp.php
@@ -43,7 +43,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Siin lehel saad hallata ja luua foorumi teadaannet, mida näidatakse igal foorumi leheküljel.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Näita seda foorumi teadaannet',
-	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Kes saab vaadata foorumi teadaannet',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Luba liikmetel sellest foorumi teadaandest keelduda',
 
 	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Igaüks',

--- a/language/et/boardannouncements_acp.php
+++ b/language/et/boardannouncements_acp.php
@@ -46,9 +46,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Luba liikmetel sellest foorumi teadaandest keelduda',
 
-	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
-	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
-	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
+	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Igaüks',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> '“Foorumi teadaande” tagatausta värv',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Sa saad muuta tagatausta värvi teadaandel, kasutades hex koodi (näiteks: FFFF80). Jäta see väli tühjaks, et kasutada vaikimisi värvi.',

--- a/language/fr/boardannouncements_acp.php
+++ b/language/fr/boardannouncements_acp.php
@@ -46,9 +46,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Permettre aux utilisateurs de masquer l’annonce du forum',
 
-	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
-	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
-	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
+	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Tous les utilisateurs',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Couleur d’arrière-plan de l’annonce du forum',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Vous pouvez modifier la couleur d’arrière-plan de l’annonce en utilisant un code hexadécimal (ex.: FFFF80). Laissez ce champ vide pour utiliser la couleur par défaut.',

--- a/language/fr/boardannouncements_acp.php
+++ b/language/fr/boardannouncements_acp.php
@@ -43,7 +43,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Sur cette page vous pouvez gérer et créer une annonce de forum qui sera affichée sur chaque page de votre forum.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Afficher l’annonce du forum',
-	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Qui peut voir l’annonce du forum',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Permettre aux utilisateurs de masquer l’annonce du forum',
 
 	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Tous les utilisateurs',

--- a/language/fr/boardannouncements_acp.php
+++ b/language/fr/boardannouncements_acp.php
@@ -43,8 +43,12 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Sur cette page vous pouvez gérer et créer une annonce de forum qui sera affichée sur chaque page de votre forum.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Afficher l’annonce du forum',
-	'BOARD_ANNOUNCEMENTS_GUESTS'			=> 'Permettre aux invités de voir l’annonce du forum',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Permettre aux utilisateurs de masquer l’annonce du forum',
+
+	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
+	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
+	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Couleur d’arrière-plan de l’annonce du forum',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Vous pouvez modifier la couleur d’arrière-plan de l’annonce en utilisant un code hexadécimal (ex.: FFFF80). Laissez ce champ vide pour utiliser la couleur par défaut.',

--- a/language/he/boardannouncements_acp.php
+++ b/language/he/boardannouncements_acp.php
@@ -45,9 +45,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'אפשר למשתמשים להסתיר את הכרזת המערכת',
 
-	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
-	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
-	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
+	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'כל אחד',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'צבע רקע של הכרזת המערכת',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'אתה יכול לשנות את צבע הרקע של ההכרזה באמצעות שימוש בקוד HEX (לדוגמה:FFF80).אל תכתוב דבר אם ברצונך להשתמש בצבע ברירת מחדל.',

--- a/language/he/boardannouncements_acp.php
+++ b/language/he/boardannouncements_acp.php
@@ -42,8 +42,12 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'כאן תוכל לנהל וליצור הכרזת מערכת שתופיע בכל עמוד במערכת שלך.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'הצג את הכרזת המערכת',
-	'BOARD_ANNOUNCEMENTS_GUESTS'			=> ' אפשר לאורחים לראות את הכרזת המערכת',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'אפשר למשתמשים להסתיר את הכרזת המערכת',
+
+	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
+	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
+	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'צבע רקע של הכרזת המערכת',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'אתה יכול לשנות את צבע הרקע של ההכרזה באמצעות שימוש בקוד HEX (לדוגמה:FFF80).אל תכתוב דבר אם ברצונך להשתמש בצבע ברירת מחדל.',

--- a/language/hr/boardannouncements_acp.php
+++ b/language/hr/boardannouncements_acp.php
@@ -46,9 +46,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Omogući korisnicima/ama zatvaranje forumskih obavijesti',
 
-	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
-	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
-	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
+	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Svatko',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Pozadinska boja forumskih obavijesti',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Pozadinsku boja forumskih obavijesti možeš mijenjati korištenjem hex kodova (npr.: FFFF80).<br />Za korištenje zadane boje, ostavi ovo polje praznim.',

--- a/language/hr/boardannouncements_acp.php
+++ b/language/hr/boardannouncements_acp.php
@@ -43,7 +43,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Ovdje možeš dodavati i upravljati forumskim obavijestima (a) koje će biti prikazane na svakoj stranici foruma.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Prikaži forumske obavijesti',
-	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Tko može vidjeti ovu forumskih obavijesti',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Omogući korisnicima/ama zatvaranje forumskih obavijesti',
 
 	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Svatko',

--- a/language/hr/boardannouncements_acp.php
+++ b/language/hr/boardannouncements_acp.php
@@ -43,8 +43,12 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Ovdje možeš dodavati i upravljati forumskim obavijestima (a) koje će biti prikazane na svakoj stranici foruma.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Prikaži forumske obavijesti',
-	'BOARD_ANNOUNCEMENTS_GUESTS'			=> 'Omogući prikaz forumskih obavijesti gostima',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Omogući korisnicima/ama zatvaranje forumskih obavijesti',
+
+	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
+	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
+	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Pozadinska boja forumskih obavijesti',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Pozadinsku boja forumskih obavijesti možeš mijenjati korištenjem hex kodova (npr.: FFFF80).<br />Za korištenje zadane boje, ostavi ovo polje praznim.',

--- a/language/it/boardannouncements_acp.php
+++ b/language/it/boardannouncements_acp.php
@@ -42,7 +42,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Qui è possibile gestire e creare un annuncio che sarà mostrato in ogni pagina del forum.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Abilita annuncio',
-	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Chi può vedere quest’annuncio',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Permetti agli utenti di chiudere quest’annuncio',
 
 	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Tutti',

--- a/language/it/boardannouncements_acp.php
+++ b/language/it/boardannouncements_acp.php
@@ -45,9 +45,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Permetti agli utenti di chiudere quest’annuncio',
 
-	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
-	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
-	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
+	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Tutti',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Colore di sfondo annuncio',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'È possibile cambiare il colore di sfondo dell’annuncio usando un codice esadecimale (per esempio FFFF80). Lasciare questo campo in bianco per usare il colore predefinito.',

--- a/language/it/boardannouncements_acp.php
+++ b/language/it/boardannouncements_acp.php
@@ -42,8 +42,12 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Qui è possibile gestire e creare un annuncio che sarà mostrato in ogni pagina del forum.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Abilita annuncio',
-	'BOARD_ANNOUNCEMENTS_GUESTS'			=> 'Permetti agli ospiti di vedere quest’annuncio',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Permetti agli utenti di chiudere quest’annuncio',
+
+	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
+	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
+	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Colore di sfondo annuncio',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'È possibile cambiare il colore di sfondo dell’annuncio usando un codice esadecimale (per esempio FFFF80). Lasciare questo campo in bianco per usare il colore predefinito.',

--- a/language/nl/boardannouncements_acp.php
+++ b/language/nl/boardannouncements_acp.php
@@ -43,12 +43,10 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Hier kan je een forumaankondiging beheren en aanmaken, die weergegeven zal worden op elke pagina van je forum.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Laat deze forumaankondiging zien',
-	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Wie kan deze forumaankondiging bekijken',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Sta gebruikers toe om deze forumaankondiging te sluiten',
 
-	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
-	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
-	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
+	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Iedereen',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Forumaankondiging-achtergrondkleur',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Je kan de achtergrondkleur van de aankondiging veranderen door gebruik te maken van een hex-code (bijv.: FFFF80). Laat dit veld leeg om de standaard kleur te gebruiken.',

--- a/language/nl/boardannouncements_acp.php
+++ b/language/nl/boardannouncements_acp.php
@@ -43,8 +43,12 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Hier kan je een forumaankondiging beheren en aanmaken, die weergegeven zal worden op elke pagina van je forum.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Laat deze forumaankondiging zien',
-	'BOARD_ANNOUNCEMENTS_GUESTS'			=> 'Sta gasten toe om deze forumaankondiging te bekijken',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Sta gebruikers toe om deze forumaankondiging te sluiten',
+
+	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
+	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
+	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Forumaankondiging-achtergrondkleur',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Je kan de achtergrondkleur van de aankondiging veranderen door gebruik te maken van een hex-code (bijv.: FFFF80). Laat dit veld leeg om de standaard kleur te gebruiken.',

--- a/language/pl/boardannouncements_acp.php
+++ b/language/pl/boardannouncements_acp.php
@@ -43,7 +43,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Tutaj możesz zarządzać i stworzyć ogłoszenie, które będzie wyświetlane na każdej stronie forum.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Wyświetlaj ogłoszenie',
-	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Kto może zobaczyć tę zobaczyć ogłoszenie',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Zezwalaj użytkownikom na zamknięcie ogłoszenia',
 
 	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Wszyscy',

--- a/language/pl/boardannouncements_acp.php
+++ b/language/pl/boardannouncements_acp.php
@@ -46,9 +46,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Zezwalaj użytkownikom na zamknięcie ogłoszenia',
 
-	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
-	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
-	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
+	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Wszyscy',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Kolor tła ogłoszenia',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Możesz zmienić kolor tła ogłoszenia używając kodu hex (szesnastkowego) np.: FFFF80. Pozostaw pole puste, aby użyć domyślnego koloru.',

--- a/language/pl/boardannouncements_acp.php
+++ b/language/pl/boardannouncements_acp.php
@@ -43,8 +43,12 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Tutaj możesz zarządzać i stworzyć ogłoszenie, które będzie wyświetlane na każdej stronie forum.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Wyświetlaj ogłoszenie',
-	'BOARD_ANNOUNCEMENTS_GUESTS'			=> 'Czy goście mogą zobaczyć ogłoszenie?',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Zezwalaj użytkownikom na zamknięcie ogłoszenia',
+
+	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
+	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
+	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Kolor tła ogłoszenia',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Możesz zmienić kolor tła ogłoszenia używając kodu hex (szesnastkowego) np.: FFFF80. Pozostaw pole puste, aby użyć domyślnego koloru.',

--- a/language/pt/boardannouncements_acp.php
+++ b/language/pt/boardannouncements_acp.php
@@ -43,8 +43,12 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Aqui pode gerir e criar um comunicado que será exibido em cada página do seu Fórum.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Ativar o comunicado',
-	'BOARD_ANNOUNCEMENTS_GUESTS'			=> 'Permitir aos visitantes ver o comunicado',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Permitir aos utilizadores fechar este comunicado',
+
+	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
+	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
+	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Cor do fundo do comunicado',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Pode mudar a cor do fundo do comunicado usando um código hexadecimal (exemplo: FFFF80). Deixe este campo em branco para usar a cor padrão.',

--- a/language/pt/boardannouncements_acp.php
+++ b/language/pt/boardannouncements_acp.php
@@ -46,9 +46,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Permitir aos utilizadores fechar este comunicado',
 
-	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
-	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
-	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
+	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Todos os usuários',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Cor do fundo do comunicado',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Pode mudar a cor do fundo do comunicado usando um código hexadecimal (exemplo: FFFF80). Deixe este campo em branco para usar a cor padrão.',

--- a/language/pt/boardannouncements_acp.php
+++ b/language/pt/boardannouncements_acp.php
@@ -43,7 +43,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Aqui pode gerir e criar um comunicado que será exibido em cada página do seu Fórum.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Ativar o comunicado',
-	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Quem pode ver este comunicado',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Permitir aos utilizadores fechar este comunicado',
 
 	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Todos os usuários',

--- a/language/pt_br/boardannouncements_acp.php
+++ b/language/pt_br/boardannouncements_acp.php
@@ -43,7 +43,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Aqui você pode gerenciar e criar um anúncio que será exibido em cada página do seu fórum.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Ativar anúncio',
-	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Quién puede ver este anúncio',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Permitir que usuários para fechar este anúncio',
 
 	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Todos los usuários',

--- a/language/pt_br/boardannouncements_acp.php
+++ b/language/pt_br/boardannouncements_acp.php
@@ -46,9 +46,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Permitir que usuários para fechar este anúncio',
 
-	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
-	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
-	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
+	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Todos los usuários',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Cor de fundo do anúncio',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Você pode mudar a cor do anúncio usando um código hexadecimal de fundo (por exemplo: FFFF80). Deixe este campo em branco para usar a cor padrão.',

--- a/language/pt_br/boardannouncements_acp.php
+++ b/language/pt_br/boardannouncements_acp.php
@@ -43,8 +43,12 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Aqui você pode gerenciar e criar um anúncio que será exibido em cada página do seu fórum.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Ativar anúncio',
-	'BOARD_ANNOUNCEMENTS_GUESTS'			=> 'Permitir acesso a visitantes para ver este anúncio',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Permitir que usuários para fechar este anúncio',
+
+	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
+	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
+	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Cor de fundo do anúncio',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Você pode mudar a cor do anúncio usando um código hexadecimal de fundo (por exemplo: FFFF80). Deixe este campo em branco para usar a cor padrão.',

--- a/language/ro/boardannouncements_acp.php
+++ b/language/ro/boardannouncements_acp.php
@@ -42,8 +42,12 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Aici puteţi gestiona sau crea anunţuri care vor fi afişate pe fiecare pagină a forumului.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Afişează acest anunţ',
-	'BOARD_ANNOUNCEMENTS_GUESTS'			=> 'Permite vizitatorilor să vizualizeze anunţurile',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Permite utilizatorilor să respingă anunţul',
+
+	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
+	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
+	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Culoarea background-ului',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Puteţi schimba culoarea de fundal a anunţului folosind un cod hex (Ex: FFFF80). Lasă acest câmp necompletat pentru a utiliza culoarea prestabilită.',

--- a/language/ro/boardannouncements_acp.php
+++ b/language/ro/boardannouncements_acp.php
@@ -45,9 +45,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Permite utilizatorilor să respingă anunţul',
 
-	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
-	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
-	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
+	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Toata lumea',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Culoarea background-ului',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Puteţi schimba culoarea de fundal a anunţului folosind un cod hex (Ex: FFFF80). Lasă acest câmp necompletat pentru a utiliza culoarea prestabilită.',

--- a/language/ro/boardannouncements_acp.php
+++ b/language/ro/boardannouncements_acp.php
@@ -42,7 +42,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Aici puteţi gestiona sau crea anunţuri care vor fi afişate pe fiecare pagină a forumului.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Afişează acest anunţ',
-	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Cine poate vedea acest anunț',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Permite utilizatorilor să respingă anunţul',
 
 	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Toata lumea',

--- a/language/ru/boardannouncements_acp.php
+++ b/language/ru/boardannouncements_acp.php
@@ -42,8 +42,12 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Здесь вы можете управлять и создавать объявления, которые будут отображаться на каждой странице вашего сайта.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Показывать эту доску объявлений',
-	'BOARD_ANNOUNCEMENTS_GUESTS'			=> 'Разрешить гостям просматривать доску объявлений',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Разрешить пользователям выключать это объявление',
+
+	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
+	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
+	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Цвет фона объявления',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Вы можете изменить цвет фона объявления, используя шестнадцатеричный код (например: FFFF80). Оставьте это поле пустым, чтобы использовать цвет фона по умолчанию.',

--- a/language/ru/boardannouncements_acp.php
+++ b/language/ru/boardannouncements_acp.php
@@ -42,12 +42,10 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Здесь вы можете управлять и создавать объявления, которые будут отображаться на каждой странице вашего сайта.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Показывать эту доску объявлений',
-	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Кто может видеть доску объявлений',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Разрешить пользователям выключать это объявление',
 
-	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
-	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
-	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
+	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Все',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Цвет фона объявления',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Вы можете изменить цвет фона объявления, используя шестнадцатеричный код (например: FFFF80). Оставьте это поле пустым, чтобы использовать цвет фона по умолчанию.',

--- a/language/sv/boardannouncements_acp.php
+++ b/language/sv/boardannouncements_acp.php
@@ -43,7 +43,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Här kan du hantera och skapa ett forummeddelande som kommer att visas på varje sida i ditt forum.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Visa detta forummeddelande',
-	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Vem kan se detta forummeddelande',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Tillåt användare att stänga detta forummeddelande',
 
 	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Alla',

--- a/language/sv/boardannouncements_acp.php
+++ b/language/sv/boardannouncements_acp.php
@@ -43,8 +43,12 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> 'Här kan du hantera och skapa ett forummeddelande som kommer att visas på varje sida i ditt forum.',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> 'Visa detta forummeddelande',
-	'BOARD_ANNOUNCEMENTS_GUESTS'			=> 'Tillåt gäster att se detta forummeddelande',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Tillåt användare att stänga detta forummeddelande',
+
+	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
+	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
+	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Forummeddelandets bakgrundsfärg',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Du kan ändra forummeddelandets bakgrundsfärg genom att ange en hex-kod (t.ex.: FFFF80). Lämna fältet tomt om du vill använda standardfärgen.',

--- a/language/sv/boardannouncements_acp.php
+++ b/language/sv/boardannouncements_acp.php
@@ -46,9 +46,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> 'Tillåt användare att stänga detta forummeddelande',
 
-	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
-	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
-	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
+	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> 'Alla',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> 'Forummeddelandets bakgrundsfärg',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> 'Du kan ändra forummeddelandets bakgrundsfärg genom att ange en hex-kod (t.ex.: FFFF80). Lämna fältet tomt om du vill använda standardfärgen.',

--- a/language/zh_cmn_hant/boardannouncements_acp.php
+++ b/language/zh_cmn_hant/boardannouncements_acp.php
@@ -46,9 +46,7 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> '允許使用者關閉這則討論區公告',
 
-	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
-	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
-	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
+	'BOARD_ANNOUNCEMENTS_EVERYONE'			=> '大家',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> '討論區公告背景顏色',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> '您可以使用十六進制代碼改變討論區公告背景顏色（例如：FFFF80）。欄位留白，則使用預設的顏色。',

--- a/language/zh_cmn_hant/boardannouncements_acp.php
+++ b/language/zh_cmn_hant/boardannouncements_acp.php
@@ -43,8 +43,12 @@ $lang = array_merge($lang, array(
 	'BOARD_ANNOUNCEMENTS_SETTINGS_EXPLAIN'	=> '在這裡，您可以管理與建立討論區公告，它將顯示在討論區的每一頁。',
 
 	'BOARD_ANNOUNCEMENTS_ENABLE'			=> '顯示這則討論區公告設定',
-	'BOARD_ANNOUNCEMENTS_GUESTS'			=> '允許訪客看見這則討論區公告',
+	'BOARD_ANNOUNCEMENTS_USERS'				=> 'Who can view this board announcement',
 	'BOARD_ANNOUNCEMENTS_DISMISS'			=> '允許使用者關閉這則討論區公告',
+
+	'BOARD_ANNOUNCEMENTS_ALL_USERS'			=> 'Everyone',
+	'BOARD_ANNOUNCEMENTS_MEMBERS_ONLY'		=> 'Members only',
+	'BOARD_ANNOUNCEMENTS_GUESTS_ONLY'		=> 'Guests only',
 
 	'BOARD_ANNOUNCEMENTS_BGCOLOR'			=> '討論區公告背景顏色',
 	'BOARD_ANNOUNCEMENTS_BGCOLOR_EXPLAIN'	=> '您可以使用十六進制代碼改變討論區公告背景顏色（例如：FFFF80）。欄位留白，則使用預設的顏色。',

--- a/migrations/v10x/m6_update_config.php
+++ b/migrations/v10x/m6_update_config.php
@@ -1,0 +1,46 @@
+<?php
+/**
+*
+* Board Announcements extension for the phpBB Forum Software package.
+*
+* @copyright (c) 2014 phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+*/
+
+namespace phpbb\boardannouncements\migrations\v10x;
+
+/**
+* Migration stage 6: Update config name
+*/
+class m6_update_config extends \phpbb\db\migration\migration
+{
+	/**
+	* Assign migration file dependencies for this migration
+	*
+	* @return array Array of migration files
+	* @static
+	* @access public
+	*/
+	static public function depends_on()
+	{
+		return array(
+			'\phpbb\boardannouncements\migrations\v10x\m1_initial_schema',
+			'\phpbb\boardannouncements\migrations\v10x\m5_enable_announcements_for_new_users',
+		);
+	}
+
+	/**
+	* Add board announcements data to the database.
+	*
+	* @return array Array of table data
+	* @access public
+	*/
+	public function update_data()
+	{
+		return array(
+			array('config.add', array('board_announcements_users', (int) !$this->config['board_announcements_guests'])),
+			array('config.remove', array('board_announcements_guests')),
+		);
+	}
+}

--- a/migrations/v10x/m6_update_config.php
+++ b/migrations/v10x/m6_update_config.php
@@ -3,7 +3,7 @@
 *
 * Board Announcements extension for the phpBB Forum Software package.
 *
-* @copyright (c) 2014 phpBB Limited <https://www.phpbb.com>
+* @copyright (c) 2016 phpBB Limited <https://www.phpbb.com>
 * @license GNU General Public License, version 2 (GPL-2.0)
 *
 */

--- a/tests/event/listener_test.php
+++ b/tests/event/listener_test.php
@@ -11,6 +11,8 @@
 
 namespace phpbb\boardannouncements\tests\event;
 
+use phpbb\boardannouncements\acp\board_announcements_module;
+
 require_once __DIR__ . '/../../../../../includes/functions.php';
 require_once __DIR__ . '/../../../../../includes/functions_content.php';
 require_once __DIR__ . '/../../../../../includes/utf/utf_tools.php';
@@ -171,8 +173,9 @@ class listener_test extends \phpbb_database_test_case
 	public function display_board_announcements_disabled_data()
 	{
 		return array(
-			array(false, true),
-			array(true, false),
+			array(false, 1, 1, board_announcements_module::ALL), // test when BA is disabled
+			array(true, 0, 1, board_announcements_module::ALL), // test when BA is disabled by the current user
+			array(true, 1, 2, board_announcements_module::GUESTS), // test when BA is only for guests but user is newly reg.
 		);
 	}
 
@@ -181,11 +184,13 @@ class listener_test extends \phpbb_database_test_case
 	 *
 	 * @dataProvider display_board_announcements_disabled_data
 	 */
-	public function test_display_board_announcements_disabled($enabled, $status)
+	public function test_display_board_announcements_disabled($enabled, $status, $user_id, $allowed_users)
 	{
 		// override config and user data
 		$this->config['board_announcements_enable'] = $enabled;
+		$this->config['board_announcements_users'] = $allowed_users;
 		$this->user->data['board_announcements_status'] = $status;
+		$this->user->data['user_id'] = $user_id;
 
 		$this->set_listener();
 

--- a/tests/functional/announcement_test.php
+++ b/tests/functional/announcement_test.php
@@ -10,6 +10,8 @@
 
 namespace phpbb\boardannouncements\tests\functional;
 
+use phpbb\boardannouncements\acp\board_announcements_module;
+
 /**
 * @group functional
 */
@@ -90,6 +92,14 @@ class announcement_test extends \phpbb_functional_test_case
 
 		$crawler = self::request('GET', 'index.php');
 		$this->assertContains('This is a board announcement test.', $crawler->filter('#phpbb_announcement')->text());
+
+		// Verify that new users won't see the announcement if it's Guest only
+		$this->db->sql_query('UPDATE ' . CONFIG_TABLE . ' SET config_value = ' .
+			(int) board_announcements_module::GUESTS . " 
+			WHERE config_name = 'board_announcements_users'");
+		$this->purge_cache();
+		$crawler = self::request('GET', 'index.php');
+		$this->assertNotContains('This is a board announcement test.', $crawler->text());
 	}
 
 	/**

--- a/tests/functional/announcement_test.php
+++ b/tests/functional/announcement_test.php
@@ -44,7 +44,7 @@ class announcement_test extends \phpbb_functional_test_case
 
 		// Test that our settings fields are found
 		$this->assertContainsLang('BOARD_ANNOUNCEMENTS_ENABLE', $crawler->text());
-		$this->assertContainsLang('BOARD_ANNOUNCEMENTS_GUESTS', $crawler->text());
+		$this->assertContainsLang('BOARD_ANNOUNCEMENTS_USERS', $crawler->text());
 		$this->assertContainsLang('BOARD_ANNOUNCEMENTS_DISMISS', $crawler->text());
 		$this->assertContainsLang('BOARD_ANNOUNCEMENTS_BGCOLOR', $crawler->text());
 		$this->assertContainsLang('BOARD_ANNOUNCEMENTS_TEXT', $crawler->text());
@@ -53,7 +53,7 @@ class announcement_test extends \phpbb_functional_test_case
 		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
 		$values = array(
 			'board_announcements_enable'	=> true,
-			'board_announcements_guests'	=> true,
+			'board_announcements_users'		=> 0,
 			'board_announcements_dismiss'	=> true,
 			'board_announcements_bgcolor'	=> 'ff0000',
 			'board_announcements_text'		=> 'This is a board announcement test.',


### PR DESCRIPTION
Not sure how I feel about this one, but here it is.

Replaced the Allow guests to view option with a pull down to allow: Everyone, Members only or Guests only to view the announcement.

Closes #105 